### PR TITLE
Host project on Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,40 @@ git checkout -b feature/metal-enhancement
 
 ## License
 NVIDIA AI Enterprise License (Linux) / MIT License (macOS Components)
+
+---
+
+## Docker Hub Instructions
+
+### Building Docker Images
+1. Build the backend Docker image:
+   ```bash
+   docker build -t <username>/backend:latest ./backend
+   ```
+
+2. Build the frontend Docker image:
+   ```bash
+   docker build -t <username>/frontend:latest ./frontend
+   ```
+
+### Tagging Docker Images
+1. Tag the backend Docker image:
+   ```bash
+   docker tag <username>/backend:latest <username>/backend:latest
+   ```
+
+2. Tag the frontend Docker image:
+   ```bash
+   docker tag <username>/frontend:latest <username>/frontend:latest
+   ```
+
+### Pushing Docker Images to Docker Hub
+1. Push the backend Docker image:
+   ```bash
+   docker push <username>/backend:latest
+   ```
+
+2. Push the frontend Docker image:
+   ```bash
+   docker push <username>/frontend:latest
+   ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,7 @@ services:
     shm_size: '16gb'
 
   backend:
-    build: 
-      context: ./backend
-      dockerfile: Dockerfile
+    image: <username>/backend:latest
     ports:
       - "8001:8001"
     volumes:
@@ -24,9 +22,7 @@ services:
       - IMAGE_ANALYSIS_API_URL=http://image-analysis:8002/v1/analyze
 
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
+    image: <username>/frontend:latest
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
Update `docker-compose.yml` and `README.md` to support hosting on Docker Hub.

* **docker-compose.yml**
  - Update `backend` service to use Docker Hub image `<username>/backend:latest`.
  - Update `frontend` service to use Docker Hub image `<username>/frontend:latest`.
  - Remove `build` context for `backend` and `frontend` services.

* **README.md**
  - Add instructions for building Docker images.
  - Add instructions for tagging Docker images.
  - Add instructions for pushing Docker images to Docker Hub.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/llama-vision-project/pull/2?shareId=15212b9b-d77c-4d16-b6b4-8ccc1cc6a675).